### PR TITLE
객관식 답안 토글 버튼 구현

### DIFF
--- a/src/components/SelectionButton/index.tsx
+++ b/src/components/SelectionButton/index.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { SelectionButtonLayout } from './style';
+
+interface SelectionButtonProps {
+  children: React.ReactNode;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const SelectionButton = ({
+  children,
+  isSelected,
+  onClick,
+}: SelectionButtonProps) => {
+  return (
+    <SelectionButtonLayout $isSelected={isSelected} onClick={onClick}>
+      {children}
+    </SelectionButtonLayout>
+  );
+};
+
+export default SelectionButton;

--- a/src/components/SelectionButton/index.tsx
+++ b/src/components/SelectionButton/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SelectionButtonLayout } from './style';
+import * as S from './style';
 
 interface SelectionButtonProps {
   children: React.ReactNode;
@@ -14,9 +14,9 @@ const SelectionButton = ({
   onClick,
 }: SelectionButtonProps) => {
   return (
-    <SelectionButtonLayout $isSelected={isSelected} onClick={onClick}>
+    <S.SelectionButtonLayout $isSelected={isSelected} onClick={onClick}>
       {children}
-    </SelectionButtonLayout>
+    </S.SelectionButtonLayout>
   );
 };
 

--- a/src/components/SelectionButton/style.ts
+++ b/src/components/SelectionButton/style.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+import { theme } from '@/styles/theme';
+
+export const SelectionButtonLayout = styled.button<{
+  $isSelected: boolean;
+  children: React.ReactNode;
+}>`
+  background-color: ${({ $isSelected }) =>
+    $isSelected ? theme.colors.main['400'] : theme.colors.gray['50']};
+  color: ${({ $isSelected }) =>
+    $isSelected ? theme.colors.gray['0'] : theme.colors.gray['400']};
+  border-radius: 4px;
+  font-size: ${theme.typography.sizes.sm};
+  font-weight: ${theme.typography.weights.medium};
+  height: 22px;
+  width: 22px;
+  margin: 0 auto 0 0;
+
+  @media (max-width: 390px) {
+    font-size: ${theme.typography.sizes.xs};
+  }
+`;

--- a/src/components/SelectionButton/style.ts
+++ b/src/components/SelectionButton/style.ts
@@ -4,7 +4,6 @@ import { theme } from '@/styles/theme';
 
 export const SelectionButtonLayout = styled.button<{
   $isSelected: boolean;
-  children: React.ReactNode;
 }>`
   background-color: ${({ $isSelected }) =>
     $isSelected ? theme.colors.main['400'] : theme.colors.gray['50']};

--- a/src/components/SelectionButtonList/index.tsx
+++ b/src/components/SelectionButtonList/index.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+
+import SelectionButton from '@/components/SelectionButton';
+
+import { SelectionButtonListLayout } from './style';
+
+const SelectionButtonList = () => {
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const handleButtonClick = (buttonId: number) => {
+    if (selected === buttonId) {
+      setSelected(null);
+    } else {
+      setSelected(buttonId);
+    }
+  };
+
+  return (
+    <SelectionButtonListLayout>
+      {[1, 2, 3, 4, 5].map((buttonId) => (
+        <SelectionButton
+          key={buttonId}
+          isSelected={selected === buttonId}
+          onClick={() => handleButtonClick(buttonId)}
+        >
+          {buttonId}
+        </SelectionButton>
+      ))}
+    </SelectionButtonListLayout>
+  );
+};
+
+export default SelectionButtonList;

--- a/src/components/SelectionButtonList/index.tsx
+++ b/src/components/SelectionButtonList/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import SelectionButton from '@/components/SelectionButton';
 
-import { SelectionButtonListLayout } from './style';
+import * as S from './style';
 
 const SelectionButtonList = () => {
   const [selected, setSelected] = useState<number | null>(null);
@@ -18,7 +18,7 @@ const SelectionButtonList = () => {
   };
 
   return (
-    <SelectionButtonListLayout>
+    <S.SelectionButtonListLayout>
       {[1, 2, 3, 4, 5].map((buttonId) => (
         <SelectionButton
           key={buttonId}
@@ -28,7 +28,7 @@ const SelectionButtonList = () => {
           {buttonId}
         </SelectionButton>
       ))}
-    </SelectionButtonListLayout>
+    </S.SelectionButtonListLayout>
   );
 };
 

--- a/src/components/SelectionButtonList/style.ts
+++ b/src/components/SelectionButtonList/style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const SelectionButtonListLayout = styled.div`
+  display: flex;
+  justify-content: left;
+  width: 100%;
+`;


### PR DESCRIPTION
## 📝 작업 내용

- 객관식 답안 토글 버튼 구현
- 객관식 답안 토글 버튼 리스트 구현

## 📸 스크린샷 (선택)

- 미선택
![image](https://github.com/user-attachments/assets/33aa6e93-8748-45f8-b2fb-4c87d6b0eaf5)

- 답안 선택
![image](https://github.com/user-attachments/assets/a70380d9-723c-4689-9b1e-8091acdc9a03)

- 선택 취소 (선택한 답안을 다시 클릭)
![image](https://github.com/user-attachments/assets/51ca01f6-c945-4a76-872c-6483c39fafa3)



## 💬 리뷰 요구사항 (선택)

- 오답일 경우의 상황은 추후에 api 연동할 때 구현해야 할거 같아서 구현하지 않았습니다.
- 답안 다중 선택은 고려하지 않고 구현했는데 만약 다중 선택이 가능하다면 추후에 수정하겠습니다.
- 답안이 항상 5개라고 생각하고 구현했는데 아닌 경우가 있으면 추후에 수정하겠습니다.
- 객관식 문제 컴포넌트가 구현될때 추가적으로 수정사항이 있을 수 있을거 같습니다.
- 컴포넌트 이름이 적절한지 봐주시면 감사하겠습니다.
