### PR TITLE
문제지 생성 페이지 추가

### DIFF
--- a/src/app/paper/create/page.tsx
+++ b/src/app/paper/create/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Fragment } from 'react';
+import { useStore } from 'zustand';
+
+import DefaultButton from '@/components/Button/DefaultButton';
+import OptionSection from '@/components/Paper/Create/OptionSection';
+import { PAPER_OPTIONS } from '@/constants/paperOption';
+import paperOptionStore from '@/store/paperOptionStore';
+
+import style from './style.module.css';
+
+const CreatePage = () => {
+  const { options, isFulfilled } = useStore(paperOptionStore);
+  const sumbitPaperOption = () => {
+    console.log(options);
+  };
+
+  return (
+    <div className={style.container}>
+      <div>
+        {PAPER_OPTIONS.map((option, index) => (
+          <Fragment key={index}>
+            <OptionSection {...option} />
+            {PAPER_OPTIONS.length - 1 !== index && (
+              <hr className={style.divider} />
+            )}
+          </Fragment>
+        ))}
+      </div>
+      <DefaultButton
+        isFull={false}
+        size='lg'
+        onClick={sumbitPaperOption}
+        disabled={!isFulfilled()}
+      >
+        <span className={style.button}>풀이 시작하기</span>
+      </DefaultButton>
+    </div>
+  );
+};
+
+export default CreatePage;

--- a/src/app/paper/create/style.module.css
+++ b/src/app/paper/create/style.module.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 60px;
+
+  padding: 0 24px;
+}
+
+.divider {
+  border: 1px solid var(--color--gray-50);
+}
+
+.button {
+  padding: 0 77px;
+}

--- a/src/components/Paper/Create/OptionBlock/index.tsx
+++ b/src/components/Paper/Create/OptionBlock/index.tsx
@@ -1,0 +1,44 @@
+import { useStore } from 'zustand';
+
+import paperOptionStore from '@/store/paperOptionStore';
+import { OptionBlockType } from '@/types/paperOptionType';
+
+import style from './style.module.css';
+
+interface OptionBlockProps extends OptionBlockType {
+  optionKey: string;
+}
+
+const OptionBlock = ({
+  title,
+  valueKey,
+  description,
+  subDescription,
+  isRecommend,
+  optionKey,
+}: OptionBlockProps) => {
+  const { options, setOption } = useStore(paperOptionStore);
+
+  const clickOptionBlock = () => {
+    setOption(optionKey, valueKey);
+  };
+
+  return (
+    <button
+      type='button'
+      className={`${style.container} ${options[optionKey] === valueKey && style.selected}`}
+      onClick={clickOptionBlock}
+    >
+      <div className={style['bedge-wrapper']}>
+        {subDescription && (
+          <p className={style['sub-description']}>{subDescription}</p>
+        )}
+        {isRecommend && <p className={style.recommend}>추천</p>}
+      </div>
+      <h3 className={style.title}>{title}</h3>
+      <p className={style.description}>{description}</p>
+    </button>
+  );
+};
+
+export default OptionBlock;

--- a/src/components/Paper/Create/OptionBlock/style.module.css
+++ b/src/components/Paper/Create/OptionBlock/style.module.css
@@ -1,0 +1,74 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  text-align: left;
+  padding: 16px;
+  border: 2px solid var(--color--gray-50);
+  border-radius: 8px;
+
+  background-color: var(--color--gray-50);
+
+  @media (max-width: 768px) {
+    padding: 10px;
+  }
+}
+
+.bedge-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+
+  & p {
+    margin-bottom: 16px;
+    padding: 4px 12px;
+    border-radius: 4px;
+
+    font-size: var(--typography--sizes-xs);
+    font-weight: var(--typography--weights-medium);
+  }
+}
+
+.wrapper-gap {
+  margin-bottom: 16px;
+}
+
+.sub-description {
+  margin-right: auto;
+  background-color: var(--color--gray-0);
+  color: var(--color--gray-500);
+}
+
+.recommend {
+  margin-left: auto;
+  background-color: var(--color--red-500);
+  color: var(--color--gray-0);
+}
+
+.title {
+  margin-bottom: 4px;
+
+  font-size: var(--typography--sizes-xl);
+  font-weight: var(--typography--weights-semibold);
+  color: var(--color--main-500);
+
+  @media (max-width: 768px) {
+    font-size: var(--typography--sizes-md);
+  }
+}
+
+.description {
+  font-size: var(--typography--sizes-sm);
+  font-weight: var(--typography--weights-regular);
+  color: var(--color--gray-500);
+
+  @media (max-width: 768px) {
+    font-size: var(--typography--sizes-sm);
+  }
+}
+
+.selected {
+  border: 2px solid var(--color--main-500);
+}

--- a/src/components/Paper/Create/OptionSection/index.tsx
+++ b/src/components/Paper/Create/OptionSection/index.tsx
@@ -1,0 +1,25 @@
+import { OptionSectionType } from '@/types/paperOptionType';
+
+import OptionBlock from '../OptionBlock';
+import style from './style.module.css';
+
+const OptionSection = ({
+  title,
+  optionKey,
+  description,
+  options,
+}: OptionSectionType) => {
+  return (
+    <div className={style.container}>
+      <h2 className={style.title}>{title}</h2>
+      <p className={style.description}>{description}</p>
+      <div className={style['option-wrapper']}>
+        {options.map((option, index) => (
+          <OptionBlock key={index} {...option} optionKey={optionKey} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default OptionSection;

--- a/src/components/Paper/Create/OptionSection/style.module.css
+++ b/src/components/Paper/Create/OptionSection/style.module.css
@@ -1,0 +1,29 @@
+.container {
+  padding: 28px 0;
+}
+
+.title {
+  margin-bottom: 4px;
+
+  font-size: var(--typography--sizes-3xl);
+  font-weight: var(--typography--weights-semibold);
+  color: var(--color--gray-700);
+}
+
+.description {
+  margin-bottom: 24px;
+
+  font-size: var(--typography--sizes-sm);
+  font-weight: var(--typography--weights-regular);
+  color: var(--color--gray-500);
+}
+
+.option-wrapper {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/constants/paperOption.ts
+++ b/src/constants/paperOption.ts
@@ -1,0 +1,122 @@
+import { OptionSectionType } from '@/types/paperOptionType';
+
+export const PAPER_OPTIONS: OptionSectionType[] = [
+  {
+    title: '단원 선택',
+    optionKey: 'chatper_id',
+    description: '학습하고자 하는 단원을 선택해주세요.',
+    options: [
+      {
+        title: 'Chapter 1',
+        valueKey: 1,
+        description:
+          'Nice campaign important short continue. Something heart crime now.',
+        subDescription: '',
+        isRecommend: false,
+      },
+      {
+        title: 'Chapter 2',
+        valueKey: 2,
+        description:
+          'Information scientist impact voice able security.\nOff local term family question add late. Agent between customer term. Wait respond hot life consumer be sport.',
+        subDescription: '',
+        isRecommend: false,
+      },
+      {
+        title: 'Chapter 3',
+        valueKey: 3,
+        description:
+          'Across simple thousand. Beat camera good several finally million together.\nPublic reason fish process others pick mention body.',
+        subDescription: '',
+        isRecommend: false,
+      },
+      {
+        title: 'Chapter 4',
+        valueKey: 4,
+        description:
+          'Race could product cost. Read agree skill story community fall high. Building officer hold cut day.',
+        subDescription: '',
+        isRecommend: false,
+      },
+      {
+        title: 'Chapter 5',
+        valueKey: 5,
+        description:
+          'Color great choose admit. Recognize often impact long deep talk lay only. Main compare interest evening apply administration.\nSupport project investment establish. Heavy throughout score.',
+        subDescription: '',
+        isRecommend: false,
+      },
+    ],
+  },
+  {
+    title: '문항 수 선택',
+    optionKey: 'question_count',
+    description: '소요 시간을 확인하고 문항 수를 선택해주세요.',
+    options: [
+      {
+        title: '5 문제',
+        valueKey: 5,
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '약 30분 소요',
+        isRecommend: false,
+      },
+      {
+        title: '10 문제',
+        valueKey: 10,
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '약 30분 소요',
+        isRecommend: false,
+      },
+      {
+        title: '20 문제',
+        valueKey: 20,
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '약 30분 소요',
+        isRecommend: false,
+      },
+      {
+        title: '30 문제',
+        valueKey: 30,
+        description:
+          '실제 모의고사 문항 수로, 깊이있는 문제풀이를 원하는 분들께 추천해요.',
+        subDescription: '약 30분 소요',
+        isRecommend: true,
+      },
+    ],
+  },
+  {
+    title: '난이도 선택',
+    optionKey: 'difficulty_level',
+    description: '배점에 따라 나뉘어있는 난이도를 선택해주세요.',
+    options: [
+      {
+        title: '랜덤',
+        valueKey: 'random',
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '모든 배점',
+        isRecommend: true,
+      },
+      {
+        title: '쉬움',
+        valueKey: 'easy',
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '2점 ~ 3점 배점',
+        isRecommend: false,
+      },
+      {
+        title: '보통',
+        valueKey: 'normal',
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '3점 배점',
+        isRecommend: false,
+      },
+      {
+        title: '어려움',
+        valueKey: 'hard',
+        description: '간단하고 빠르게 머리를 풀고 싶은 분들께 추천해요.',
+        subDescription: '4점 배점',
+        isRecommend: false,
+      },
+    ],
+  },
+];

--- a/src/store/paperOptionStore.ts
+++ b/src/store/paperOptionStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand';
+
+import { PAPER_OPTIONS } from '@/constants/paperOption';
+
+interface PaperOptionAction {
+  setOption: (option: string, value: string | number) => void;
+  isFulfilled: () => boolean;
+}
+
+interface PaperOptionState {
+  options: Record<string, string | number | null>;
+}
+
+const createDefaultPaperOption = (): PaperOptionState => {
+  const defaultOptions: Record<string, string | number | null> = {};
+
+  PAPER_OPTIONS.forEach((option) => {
+    defaultOptions[option.optionKey] = null;
+  });
+
+  return { options: defaultOptions };
+};
+
+const defaultPaperOption = createDefaultPaperOption();
+
+const paperOptionStore = create<PaperOptionAction & PaperOptionState>(
+  (set, get) => ({
+    ...defaultPaperOption,
+
+    setOption: (option: string, value: string | number) =>
+      set((state) => ({
+        options: {
+          ...state.options,
+          [option]: state.options[option] === value ? null : value,
+        },
+      })),
+
+    isFulfilled: () =>
+      !Object.values(get().options).some((value) => value === null),
+  }),
+);
+
+export default paperOptionStore;

--- a/src/types/paperOptionType.ts
+++ b/src/types/paperOptionType.ts
@@ -1,0 +1,14 @@
+export interface OptionBlockType {
+  title: string;
+  valueKey: string | number;
+  description: string;
+  subDescription: string;
+  isRecommend: boolean;
+}
+
+export interface OptionSectionType {
+  title: string;
+  optionKey: string;
+  description: string;
+  options: OptionBlockType[];
+}


### PR DESCRIPTION
## 📝 작업 내용
- [x] 문제지 생성 페이지 추가
  - [x] 각 문제지 옵션 별 영역 구분 컴포넌트 추가
  - [x] 각 문제지 옵션 선택지 블록 컴포넌트 추가
  - [x]  문제지 옵션 상수 추가

## 📸 스크린샷
![Feb-03-2025 16-33-55](https://github.com/user-attachments/assets/5a54fb5a-0ade-4407-8bf7-0e7a92aebf9f)


## 💬 특이사항
- 백엔드 분들과 논의했을때 현재 MVP 수준에서 단원이 픽스되어 있기 때문에 프론트 딴에서 상수화 하여 사용하는 쪽으로 진행하려고 합니다.
- 추후 api 로직 작업이 별도 PR로 올라갈 예정이며, 그 때 단원명이 보다 구체적으로 설정될 예정입니다.
